### PR TITLE
Require relative console printer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/lib/brute_force_solver.rb
+++ b/lib/brute_force_solver.rb
@@ -1,5 +1,6 @@
 require "set"
 require_relative "grid"
+require_relative "console_printer"
 
 class BruteForceSolver
   def initialize(n)
@@ -18,6 +19,11 @@ class BruteForceSolver
     grid
   end
 
+  def print
+    printed_grid = ConsolePrinter.new(grid)
+    printed_grid.print
+  end
+  
   private
 
   attr_reader :invalid_pos, :queen_pos, :grid

--- a/lib/brute_force_solver.rb
+++ b/lib/brute_force_solver.rb
@@ -20,8 +20,7 @@ class BruteForceSolver
   end
 
   def print
-    printed_grid = ConsolePrinter.new(grid)
-    printed_grid.print
+    ConsolePrinter.new(grid).print
   end
   
   private

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -2,6 +2,7 @@ require "forwardable"
 require_relative "move"
 require_relative "token"
 
+
 class Grid
   extend Forwardable
   def_delegators :@store, :each, :length, :[], :transpose

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -36,4 +36,30 @@ describe Grid do
 
     expect(result).to eq(false)
   end
+
+    it "does not place queen if queen is already in row" do
+    grid = Grid.new(4)
+    grid.place_queen(0, 0)
+
+    result = grid.place_queen(0, 1)
+
+    expect(result).to eq(false)
+  end
+
+  it "does not place queen if queen is already in col" do
+    grid = Grid.new(4)
+    grid.place_queen(0, 0)
+
+    result = grid.place_queen(1, 0)
+
+    expect(result).to eq(false)
+  end
+
+
 end
+
+
+
+
+
+


### PR DESCRIPTION
Did another simple change to integrate in the ConsolePrinter to BruteForceSolver. 

Thinking about ways to implement backtracking while preserving the random choice dynamic. If I can't figure something out I may do a rewrite to a known backtracking method just to get the practice. 